### PR TITLE
ViewModel Implementation and tests

### DIFF
--- a/CatUnitTesting.xcodeproj/project.pbxproj
+++ b/CatUnitTesting.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2AB5F8B82648565F003EA638 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB5F8B72648565F003EA638 /* ViewModel.swift */; };
+		2AB5F8C026486C3C003EA638 /* CatsDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB5F8BF26486C3C003EA638 /* CatsDataProvider.swift */; };
+		2AB5F8C726487811003EA638 /* ViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB5F8C626487811003EA638 /* ViewModelTests.swift */; };
+		2AB5F8CD2648832F003EA638 /* MokcCatsDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB5F8CC2648832F003EA638 /* MokcCatsDataProviderTests.swift */; };
 		9204581D263AAEF300E82F4E /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9204581C263AAEF300E82F4E /* MockURLProtocol.swift */; };
 		92045823263AB0FF00E82F4E /* NetworkRequestWithMockURLSessionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92045822263AB0FF00E82F4E /* NetworkRequestWithMockURLSessionTest.swift */; };
 		920E60D326395CC300581F5D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920E60D226395CC300581F5D /* AppDelegate.swift */; };
@@ -32,6 +36,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2AB5F8B72648565F003EA638 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		2AB5F8BF26486C3C003EA638 /* CatsDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatsDataProvider.swift; sourceTree = "<group>"; };
+		2AB5F8C626487811003EA638 /* ViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelTests.swift; sourceTree = "<group>"; };
+		2AB5F8CC2648832F003EA638 /* MokcCatsDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MokcCatsDataProviderTests.swift; sourceTree = "<group>"; };
 		9204581C263AAEF300E82F4E /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		92045822263AB0FF00E82F4E /* NetworkRequestWithMockURLSessionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequestWithMockURLSessionTest.swift; sourceTree = "<group>"; };
 		920E60CF26395CC300581F5D /* CatUnitTesting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CatUnitTesting.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -68,6 +76,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2AB5F8BB26485A93003EA638 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				920E60F02639600300581F5D /* NetworkRequest.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		2AB5F8BE26486C23003EA638 /* DataProvider */ = {
+			isa = PBXGroup;
+			children = (
+				2AB5F8BF26486C3C003EA638 /* CatsDataProvider.swift */,
+			);
+			path = DataProvider;
+			sourceTree = "<group>";
+		};
+		2AB5F8C52648728D003EA638 /* ViewModelTests */ = {
+			isa = PBXGroup;
+			children = (
+				2AB5F8C626487811003EA638 /* ViewModelTests.swift */,
+				2AB5F8CC2648832F003EA638 /* MokcCatsDataProviderTests.swift */,
+			);
+			path = ViewModelTests;
+			sourceTree = "<group>";
+		};
 		92045820263AB09800E82F4E /* Real HTTP Reqeuest */ = {
 			isa = PBXGroup;
 			children = (
@@ -89,6 +122,8 @@
 			isa = PBXGroup;
 			children = (
 				920E60D126395CC300581F5D /* CatUnitTesting */,
+				2AB5F8BE26486C23003EA638 /* DataProvider */,
+				2AB5F8BB26485A93003EA638 /* Services */,
 				920E61012639880B00581F5D /* CatUnitTestingTests */,
 				920E60D026395CC300581F5D /* Products */,
 			);
@@ -130,7 +165,7 @@
 		920E60E926395F1900581F5D /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				920E60F02639600300581F5D /* NetworkRequest.swift */,
+				2AB5F8B72648565F003EA638 /* ViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -155,6 +190,7 @@
 		920E61012639880B00581F5D /* CatUnitTestingTests */ = {
 			isa = PBXGroup;
 			children = (
+				2AB5F8C52648728D003EA638 /* ViewModelTests */,
 				92045821263AB0AF00E82F4E /* Mock URLSession Request */,
 				92045820263AB09800E82F4E /* Real HTTP Reqeuest */,
 				920E61042639880B00581F5D /* Info.plist */,
@@ -265,9 +301,11 @@
 				920E61232639A74F00581F5D /* CatModelMock.swift in Sources */,
 				920E60F42639605C00581F5D /* CatModel.swift in Sources */,
 				920E60D726395CC300581F5D /* ViewController.swift in Sources */,
+				2AB5F8C026486C3C003EA638 /* CatsDataProvider.swift in Sources */,
 				920E60D326395CC300581F5D /* AppDelegate.swift in Sources */,
 				920E60D526395CC300581F5D /* SceneDelegate.swift in Sources */,
 				920E60ED26395F4100581F5D /* Protocol.swift in Sources */,
+				2AB5F8B82648565F003EA638 /* ViewModel.swift in Sources */,
 				920E60F12639600300581F5D /* NetworkRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -278,6 +316,8 @@
 			files = (
 				920E610F2639885100581F5D /* NetworkRequestTest.swift in Sources */,
 				9204581D263AAEF300E82F4E /* MockURLProtocol.swift in Sources */,
+				2AB5F8C726487811003EA638 /* ViewModelTests.swift in Sources */,
+				2AB5F8CD2648832F003EA638 /* MokcCatsDataProviderTests.swift in Sources */,
 				92045823263AB0FF00E82F4E /* NetworkRequestWithMockURLSessionTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CatUnitTesting/Controller/ViewController.swift
+++ b/CatUnitTesting/Controller/ViewController.swift
@@ -4,81 +4,83 @@
 //
 //  Created by Niclas Jeppsson on 28/04/2021.
 //
-
+import Combine
+import SwiftUI
 import UIKit
 
 class ViewController: UIViewController {
+  
+  //Text Info Label
+  private let textLabel:UILabel = {
+    let textLabel = UILabel()
+    textLabel.font = UIFont(name: "Helvetica", size: 20)
+    textLabel.textAlignment = .center
+    textLabel.adjustsFontSizeToFitWidth = true
+    textLabel.numberOfLines = 10
+    textLabel.textColor = .black
+    textLabel.translatesAutoresizingMaskIntoConstraints = false
+    return textLabel
+  }()
+  
+  //Text Number Label
+  private let numberOfCats:UILabel = {
+    let numberOfCats = UILabel()
+    numberOfCats.font = UIFont.boldSystemFont(ofSize: 20)
+    numberOfCats.textAlignment = .center
+    numberOfCats.translatesAutoresizingMaskIntoConstraints = false
+    return numberOfCats
+  }()
+  
+  private var cancellables: Set<AnyCancellable> = []
+  @ObservedObject
+  private var viewModel: ViewModel
+  
+  //Initialises APIServiceImpl
+  init(viewModel: ViewModel) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setup()
+    viewModel.start()
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    viewModel.$alert.sink { [weak self] text in
+      guard let text = text else { return }
+      let alert = UIAlertController(title: "Error", message: text, preferredStyle: .alert)
+      alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default))
+      self?.present(alert, animated: true, completion: nil)
+    }.store(in: &cancellables)
+  }
+  
+  //View Setup
+  private func setup(){
     
-    //Text Info Label
-    let textLabel:UILabel = {
-        let textLabel = UILabel()
-        textLabel.font = UIFont(name: "Helvetica", size: 20)
-        textLabel.textAlignment = .center
-        textLabel.adjustsFontSizeToFitWidth = true
-        textLabel.numberOfLines = 10
-        textLabel.textColor = .black
-        textLabel.translatesAutoresizingMaskIntoConstraints = false
-        return textLabel
-    }()
+    view.backgroundColor = .white
     
-    //Text Number Label
-    let numberOfCats:UILabel = {
-        let numberOfCats = UILabel()
-        numberOfCats.font = UIFont.boldSystemFont(ofSize: 20)
-        numberOfCats.textAlignment = .center
-        numberOfCats.translatesAutoresizingMaskIntoConstraints = false
-        return numberOfCats
-    }()
+    view.addSubview(textLabel)
+    view.addSubview(numberOfCats)
     
-    //Dependency Inversion
-    var networkRequest:APICall!
+    NSLayoutConstraint.activate([textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor), textLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor), textLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor), textLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor), numberOfCats.bottomAnchor.constraint(equalTo: textLabel.topAnchor), numberOfCats.centerXAnchor.constraint(equalTo: view.centerXAnchor)])
     
-    //Initialises networkRequest
-    init(catInfoViewModel:APICall){
-        super.init(nibName: nil, bundle: nil)
-        self.networkRequest = catInfoViewModel
-    }
+    viewModel.$title.sink { [weak self] in
+      self?.title = $0
+    }.store(in: &cancellables)
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    viewModel.$numberOfFacts.sink { [weak self] in
+      self?.numberOfCats.text = $0
+    }.store(in: &cancellables)
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        //View Setup
-        setup()
-        
-        //Networking
-        networkRequest.getItems(url: "https://cat-fact.herokuapp.com/facts", resultType: [CatModel].self) { (result) in
-            
-            DispatchQueue.main.async {
-                self.textLabel.text = "Cat Facts: "
-                switch result {
-                case .success(let catModel):
-                  self.numberOfCats.text = "Number of Cat Facts: \(catModel.count)"
-                    for catFact in catModel {
-                        self.textLabel.text!.append("\n\(catFact.text)")
-                    }
-                case.failure(let networkError):
-                    print(networkError)
-                    self.textLabel.text = networkError.localizedDescription
-                }
-            }
-        }
-        
-    }
-    
-    //View Setup
-    private func setup(){
-        
-        view.backgroundColor = .white
-        
-        view.addSubview(textLabel)
-        view.addSubview(numberOfCats)
-        
-        NSLayoutConstraint.activate([textLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor), textLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor), textLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor), textLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor), numberOfCats.bottomAnchor.constraint(equalTo: textLabel.topAnchor), numberOfCats.centerXAnchor.constraint(equalTo: view.centerXAnchor)])
-    }
-    
-    
+    viewModel.$catFacts.sink { [weak self] in
+      self?.textLabel.text = $0
+    }.store(in: &cancellables)
+  }
 }

--- a/CatUnitTesting/Protocol/Protocol.swift
+++ b/CatUnitTesting/Protocol/Protocol.swift
@@ -17,8 +17,8 @@ enum NetworkError:Error {
 
 // The name of the protocol and the signature were already generic (taking a T: Codable).
 // I therefore went all in changing the name of the func
-// Also, I removed the number of items - it is realy no standard to find such indicaiton in a APICall etc.considering it is esier to get ti from the received array count (see my change in the VC).
+// Also, I removed the number of items - it is realy no standard to find such indicaiton in a APIService etc.considering it is esier to get ti from the received array count (see my change in the VC).
 // I didn't touch the signature, but an improvement would be imo: func getItems<T: [Codable]>(...) so you can omit the [] later on and also it sounds a bit more clear this way since it already state we;l get an array of Codable
-protocol APICall {
+protocol APIService {
     func getItems<T:Codable>(url:String, resultType:[T].Type, completion: @escaping (Result<[T], NetworkError>) -> Void)
 }

--- a/CatUnitTesting/SceneDelegate.swift
+++ b/CatUnitTesting/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         
         
-        let vc = ViewController(catInfoViewModel: NetworkRequest())
+      let vc = ViewController(viewModel: ViewModel(dataProvider: CatsDataProviderImpl(apiService: APIServiceImpl())))
         
         window?.rootViewController = vc
         

--- a/CatUnitTesting/ViewModel/ViewModel.swift
+++ b/CatUnitTesting/ViewModel/ViewModel.swift
@@ -1,0 +1,37 @@
+import Combine
+import Foundation
+
+class ViewModel: ObservableObject {
+  @Published
+  private (set) var title: String = "Cat Facts:"
+  @Published
+  private (set) var numberOfFacts: String = ""
+  @Published
+  private (set) var catFacts: String = ""
+  @Published
+  private (set) var alert: String?
+  
+  private let dataProvider: CatsDataProvider
+  
+  init(dataProvider: CatsDataProvider) {
+    self.dataProvider = dataProvider
+  }
+  
+  func start() {
+    dataProvider.getCatFacts(maxItems: 3) { (result) in
+      DispatchQueue.main.async { [weak self] in
+        switch result {
+        case .success(let catModel):
+          self?.numberOfFacts = "Number of Cat Facts: \(catModel.count)"
+          var cumulativeString = ""
+          for catFact in catModel {
+            cumulativeString.append("\n\(catFact.text)")
+          }
+          self?.catFacts = cumulativeString
+        case.failure(let networkError):
+          self?.alert = networkError.localizedDescription
+        }
+      }
+    }
+  }
+}

--- a/CatUnitTestingTests/Mock URLSession Request/NetworkRequestWithMockURLSessionTest.swift
+++ b/CatUnitTestingTests/Mock URLSession Request/NetworkRequestWithMockURLSessionTest.swift
@@ -1,5 +1,5 @@
 //
-//  NetworkRequestWithMockURLSessionTest.swift
+//  APIServiceImplWithMockURLSessionTest.swift
 //  CatUnitTestingTests
 //
 //  Created by Niclas Jeppsson on 29/04/2021.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import CatUnitTesting
 
-class NetworkRequestWithMockURLSessionTest: XCTestCase {
+class APIServiceImplWithMockURLSessionTest: XCTestCase {
   
   private var encoder: JSONEncoder!
   
@@ -22,7 +22,7 @@ class NetworkRequestWithMockURLSessionTest: XCTestCase {
     super.tearDown()
   }
   
-  func testNetworkRequest_200Response() throws {
+  func testAPIServiceImpl_200Response() throws {
     //GIVEN
     
     //Setting Up URLSession Using A Mock Protocol
@@ -40,11 +40,11 @@ class NetworkRequestWithMockURLSessionTest: XCTestCase {
     }
     
     //Injecting Mock URLSession to SUT
-    let sut = NetworkRequest(urlSession: urlSession)
+    let sut = APIServiceImpl(urlSession: urlSession)
     
     let url = "https://cat-fact.herokuapp.com/facts"
     
-    let expect = expectation(description: "NetworkRequest Response Expectation")
+    let expect = expectation(description: "APIServiceImpl Response Expectation")
     
     // WHEN
     sut.getItems(url: url, resultType: [CatModel].self) { result in
@@ -63,7 +63,7 @@ class NetworkRequestWithMockURLSessionTest: XCTestCase {
     self.waitForExpectations(timeout: 01)
   }
   
-  func testNetworkRequest_400Response_withBadModelError() throws {
+  func testAPIServiceImpl_400Response_withBadModelError() throws {
     
     // GIVEN
     
@@ -81,11 +81,11 @@ class NetworkRequestWithMockURLSessionTest: XCTestCase {
     }
     
     //Injecting Mock URLSession to SUT
-    let sut = NetworkRequest(urlSession: urlSession)
+    let sut = APIServiceImpl(urlSession: urlSession)
     
     let url = "https://cat-fact.herokuapp.com/facts"
     
-    let expect = expectation(description: "NetworkRequest Response Expectation")
+    let expect = expectation(description: "APIServiceImpl Response Expectation")
     
     // WHEN
     sut.getItems(url: url, resultType: [CatModel].self) { result in
@@ -102,8 +102,8 @@ class NetworkRequestWithMockURLSessionTest: XCTestCase {
     self.waitForExpectations(timeout: 01)
   }
   
-  // Oh look: this test actually fails, highlighting an issue with the implementation of the NetworkRequest -  which was otherwise going undetected.
-  func testNetworkRequest_400Response_withBadURL() throws {
+  // Oh look: this test actually fails, highlighting an issue with the implementation of the APIServiceImpl -  which was otherwise going undetected.
+  func testAPIServiceImpl_400Response_withBadURL() throws {
     
     // GIVEN
     
@@ -121,11 +121,11 @@ class NetworkRequestWithMockURLSessionTest: XCTestCase {
     }
     
     //Injecting Mock URLSession to SUT
-    let sut = NetworkRequest(urlSession: urlSession)
+    let sut = APIServiceImpl(urlSession: urlSession)
     
     let badUrlString = "http://cats.facebook.com/||?!"
     
-    let expect = expectation(description: "NetworkRequest Response Expectation")
+    let expect = expectation(description: "APIServiceImpl Response Expectation")
     
     // WHEN
     sut.getItems(url: badUrlString, resultType: [CatModel].self) { result in

--- a/CatUnitTestingTests/Real HTTP Reqeuest/NetworkRequestTest.swift
+++ b/CatUnitTestingTests/Real HTTP Reqeuest/NetworkRequestTest.swift
@@ -8,13 +8,13 @@
 import XCTest
 @testable import CatUnitTesting
 
-class NetworkRequestTest: XCTestCase {
+class APIServiceImplTest: XCTestCase {
   
-  var sut:NetworkRequest!
+  var sut:APIServiceImpl!
   
   override func setUpWithError() throws {
     try super.setUpWithError()
-    sut = NetworkRequest()
+    sut = APIServiceImpl()
   }
   
   override func tearDownWithError() throws {
@@ -22,12 +22,12 @@ class NetworkRequestTest: XCTestCase {
     try super.tearDownWithError()
   }
   
-  func testSuccessfulNetworkRequest(){
+  func testSuccessfulAPIServiceImpl(){
     
     //given
     let url = "https://cat-fact.herokuapp.com/facts"
     let response = "Cats make about 100 different sounds. Dogs make only about 10."
-    let expectation = self.expectation(description: "Successful NetworkRequest Reponse")
+    let expectation = self.expectation(description: "Successful APIServiceImpl Reponse")
     
     //when
     sut.getItems(url: url, resultType: [CatModel].self) { (result) in

--- a/CatUnitTestingTests/ViewModelTests/MokcCatsDataProviderTests.swift
+++ b/CatUnitTestingTests/ViewModelTests/MokcCatsDataProviderTests.swift
@@ -1,0 +1,11 @@
+//
+//  MokcCatsDataProviderTests.swift
+//  CatUnitTestingTests
+//
+//  Created by Alessandro Manni on 09/05/2021.
+//
+
+import Foundation
+
+// Little exercise: based on what you've seen in ViewModel tests, can you now write soem tes for this layer, verifying, for instance, that the
+// maxNumber parameter works? Note that this class too doesn't take a concrete type but any object conforming to APIModel protocol.

--- a/CatUnitTestingTests/ViewModelTests/ViewModelTests.swift
+++ b/CatUnitTestingTests/ViewModelTests/ViewModelTests.swift
@@ -1,0 +1,85 @@
+//
+//  ViewModelTests.swift
+//  CatUnitTestingTests
+//
+//  Created by Alessandro Manni on 09/05/2021.
+//
+
+import XCTest
+import Combine
+@testable import CatUnitTesting
+
+class ViewModelTests: XCTestCase {
+  private var dataProvider: MokcCatsDataProvider!
+  private var viewModel: ViewModel!
+  private var cancellables: Set<AnyCancellable>!
+  
+  override func setUp() {
+    super.setUp()
+    cancellables = Set<AnyCancellable>()
+    dataProvider = MokcCatsDataProvider()
+    viewModel = ViewModel(dataProvider: dataProvider)
+  }
+
+  override func tearDown() {
+    viewModel = nil
+    dataProvider = nil
+    cancellables = nil
+    super.tearDown()
+  }
+  
+  func test_WhenStartIsInvoked_hitsDataProvider() {
+    viewModel.start()
+    XCTAssertEqual(dataProvider.didInvokeGetCatFacts, 1)
+  }
+  
+  // Little note for Niclas: We immediately receive the initial value and then the one from the DataProvider - hence we need the expectation and fullfilmentCount in order to wait till the 2nd value is received. But a part the little complication there are no complex networking mocks to handle etc. all is done with a rather dumb MokcCatsDataProvider thanks to dependency inversion (confomrance to protocol atsDataProvider). How convenient is that?
+  func test_WhenDataProviderResultIsSuccess_ViewModelPropertiesAreSetAccordingly() {
+    let numberOfItems = 2
+    let ext = expectation(description: "Waiting to receive first fetched value")
+    ext.expectedFulfillmentCount = 2
+    dataProvider.result = .success(catModels(number: numberOfItems))
+    viewModel.start()
+    viewModel.$numberOfFacts.sink { _ in
+      ext.fulfill()
+    }.store(in: &cancellables)
+    waitForExpectations(timeout: 01)
+    XCTAssertEqual(viewModel.title, "Cat Facts:")
+    XCTAssertEqual(viewModel.numberOfFacts , "Number of Cat Facts: \(numberOfItems)")
+    XCTAssertEqual(viewModel.catFacts, "\nModel n1\nModel n2")
+    XCTAssertNil(viewModel.alert)
+  }
+  
+  func test_WhenDataProviderResultIsFailure_ViewModelPropertiesAreSetAccordingly() {
+    let ext = expectation(description: "Waiting to receive first fetched value")
+    ext.expectedFulfillmentCount = 2
+    dataProvider.result = .failure(NetworkError.noData)
+    viewModel.start()
+    viewModel.$alert.sink { _ in
+      ext.fulfill()
+    }.store(in: &cancellables)
+    waitForExpectations(timeout: 01)
+    XCTAssertEqual(viewModel.title, "Cat Facts:")
+    XCTAssertEqual(viewModel.numberOfFacts, "")
+    XCTAssertEqual(viewModel.catFacts, "")
+    XCTAssertNotNil(viewModel.alert)
+  }
+  
+  private func catModels(number: Int) -> [CatModel] {
+    Range(1...number).map {
+      CatModel(text: "Model n\($0)")
+    }
+  }
+}
+
+
+final private class MokcCatsDataProvider: CatsDataProvider {
+  var result: Result<[CatModel], NetworkError> = .failure(NetworkError.noData)
+  private(set) var didInvokeGetCatFacts = 0
+  
+  func getCatFacts(maxItems: Int, completion: @escaping (Result<[CatModel], NetworkError>) -> Void) {
+    didInvokeGetCatFacts += 1
+    completion(result)
+  }
+}
+

--- a/DataProvider/CatsDataProvider.swift
+++ b/DataProvider/CatsDataProvider.swift
@@ -1,0 +1,25 @@
+//
+//  CatsDataProvider.swift
+//  CatUnitTesting
+//
+//  Created by Alessandro Manni on 09/05/2021.
+//
+
+protocol CatsDataProvider {
+  func getCatFacts(maxItems: Int, completion: @escaping (Result<[CatModel], NetworkError>) -> Void)
+}
+
+struct CatsDataProviderImpl: CatsDataProvider {
+  
+  let apiService: APIService
+  
+  func getCatFacts(maxItems: Int, completion: @escaping (Result<[CatModel], NetworkError>) -> Void) {
+    apiService.getItems(url: "https://cat-fact.herokuapp.com/facts",
+                        resultType: [CatModel].self) { result in
+      completion(result.map {
+        Array($0.prefix(maxItems))
+      })
+    }
+  }
+  
+}

--- a/Services/NetworkRequest.swift
+++ b/Services/NetworkRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class NetworkRequest {
+class APIServiceImpl {
     
     //Used when Mocking URLSession. Otherwise .shared
     private var urlSession:URLSession!
@@ -17,7 +17,7 @@ class NetworkRequest {
     }
 }
 
-extension NetworkRequest:APICall {
+extension APIServiceImpl: APIService {
     
     func getItems<T>(url: String, resultType: [T].Type, completion: @escaping (Result<[T], NetworkError>) -> Void) where T : Decodable, T : Encodable {
         


### PR DESCRIPTION
So this is just to answer your last question(s) and specifically how you'd adopt dependency inversion and test a ViewModel <-> Service layers.
I did:
- add a ViewModel class that is concrete and injected in the ViewController MVVM style - I didn't want to use KVOs for observation so I used Combine which is far easier - you can skip this stuff as it is not relevant for our purpose. I did that since you use MVVM and apparently your team doesn't bother to reuse ViewControllers with different ViewModels etc so let's skip dependency inversion here. But note how the introduction of a ViewModel clarified the responsibilities better (eg ViewController doesn't do network calls directly).
- I added a CatsDataProvider protocol and class to interface API and ViewModel - so, again, ViewModel doesn't have any notion where data comes from. Tomorrow you might want to use CoreData etc and this won't affect ViewModel at all. It's called Facade pattern.If you ask your Android colleagues about Repository pattern, they are likely to know (it's more adopted in their community than in iOS).
- I added tests for the ViewModel showcasing how to use dependency inversion in order to inject a mock and reduce enormously the complexity of the implementation. This also allows to test stuff in isolation as you should do for unit tests - getting rid of possible issues coming from different layers: no network stuff here, we can only test in isolation how the viewModel transform a Result<[CatModel], Error> into a series of strings.  And that's it.
- I added an empty test for CatsDataProvider as an exercise for you to implement on the basis of the above.
I hope this starts to clarify the matter and demonstrate some of the advantages of using dependency inversion.

More info on DependencyInversion and CleanArchitecture here from "Uncle" Bob Martin: https://www.youtube.com/watch?v=o_TH-Y78tt4